### PR TITLE
Mark the package as having no side-effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "type": "git",
     "url": "https://github.com/d3/d3-scale-chromatic.git"
   },
+  "sideEffects": false,
   "scripts": {
     "pretest": "rollup -c",
     "test": "tape 'test/**/*-test.js' && eslint src",


### PR DESCRIPTION
This allows for better tree-shaking when using only part of the package when using webpack. By default, it assumes packages have side-effects and so they cannot be skipped by the tree-shaking.

Rollup does not benefit from this (yet) because its equivalent feature is based on a configuration setting `treeshake.pureExternalModules` which is all-or-nothing.

Here is the effect in my app when I add this in the package.json and analyse the bundle before and after.

Before:
![d3_scale_chromatic_side_effects](https://user-images.githubusercontent.com/439401/56902673-0e114a00-6a9b-11e9-80e0-b9bec7d03404.png)

After:
![d3_scale_chromatic_no_side_effects](https://user-images.githubusercontent.com/439401/56902679-110c3a80-6a9b-11e9-8435-56c0cb48c719.png)

In the second image, `d3-scale-chromatic` is the small column on the right, which contains only `colors` and `categorical/category10`, as that's what I use.


